### PR TITLE
Idle unbooking

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	DiscordToken       string   `json:"discord_token"`
 	DefaultChannel     string   `json:"default_channel"`
 	AcceptableChannels []string `json:"acceptable_channels"`
+	MaxIdleMinutes     int      `json:"max_idle_minutes"`
+	MinPlayers         int      `json:"min_players"`
 	Servers            []Server `json:"servers"`
 }
 

--- a/config.json.example
+++ b/config.json.example
@@ -5,6 +5,8 @@
     [
         "channel id"
     ],
+    "max_idle_minutes": 2,
+    "min_players": 2,
     "servers":
     [
         {

--- a/cron.go
+++ b/cron.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+// Check if any servers are ready to be unbooked by the automatic timeout after 4 hours.
+func CheckUnbookServers() {
+	// Iterate through servers.
+	for i := 0; i < len(Conf.Servers); i++ {
+		since := time.Since(Conf.Servers[i].GetBookedTime())
+		if !Conf.Servers[i].IsAvailable() && since > (4*time.Hour) {
+			UserID := Conf.Servers[i].GetBooker()
+			UserMention := Conf.Servers[i].GetBookerMention()
+
+			// Remove the user's booked state.
+			Users[UserID] = false
+			UserServers[UserID] = nil
+
+			// Unbook the server.
+			Conf.Servers[i].Unbook()
+
+			// Upload STV demos
+			STVMessage, err := Conf.Servers[i].UploadSTV()
+
+			// Send 'returned' message
+			Session.ChannelMessageSend(Conf.DefaultChannel, fmt.Sprintf("%s: Your server was automatically unbooked.", UserMention))
+
+			// Send 'stv' message, if it uploaded successfully.
+			if err == nil {
+				Session.ChannelMessageSend(Conf.DefaultChannel, fmt.Sprintf("%s: %s", UserMention, STVMessage))
+			}
+
+			UpdateGameString()
+
+			log.Println(fmt.Sprintf("Automatically unbooked server \"%s\" from \"%s\"", Conf.Servers[i].Name, UserID))
+		}
+	}
+}

--- a/cron.go
+++ b/cron.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"time"
+
+	"github.com/kidoman/go-steam"
 )
 
 // Check if any servers are ready to be unbooked by the automatic timeout after 4 hours.
@@ -36,6 +38,62 @@ func CheckUnbookServers() {
 			UpdateGameString()
 
 			log.Println(fmt.Sprintf("Automatically unbooked server \"%s\" from \"%s\"", Conf.Servers[i].Name, UserID))
+		}
+	}
+}
+
+func CheckIdleMinutes() {
+	// Iterate through servers.
+	for i := 0; i < len(Conf.Servers); i++ {
+		if !Conf.Servers[i].IsAvailable() {
+			go func(Serv *Server) {
+				server, err := steam.Connect(Serv.Address)
+				if err != nil {
+					log.Println(fmt.Sprintf("Failed to connect to server \"%s\":", Serv.Name), err)
+					return
+				}
+
+				defer server.Close()
+
+				info, err := server.Info()
+				if err != nil {
+					log.Println(fmt.Sprintf("Failed to query server \"%s\":", Serv.Name), err)
+					return
+				}
+
+				if info.Players < Conf.MinPlayers {
+					Serv.AddIdleMinute()
+				} else {
+					Serv.ResetIdleMinutes()
+				}
+
+				if Serv.GetIdleMinutes() >= Conf.MaxIdleMinutes {
+					UserID := Serv.GetBooker()
+					UserMention := Serv.GetBookerMention()
+
+					// Remove the user's booked state.
+					Users[UserID] = false
+					UserServers[UserID] = nil
+
+					// Unbook the server.
+					Serv.Unbook()
+
+					// Upload STV demos
+					STVMessage, err := Serv.UploadSTV()
+
+					// Send 'returned' message
+					Session.ChannelMessageSend(Conf.DefaultChannel, fmt.Sprintf("%s: Your server was automatically unbooked.", UserMention))
+
+					// Send 'stv' message, if it uploaded successfully.
+					if err == nil {
+						Session.ChannelMessageSend(Conf.DefaultChannel, fmt.Sprintf("%s: %s", UserMention, STVMessage))
+					}
+
+					UpdateGameString()
+
+					log.Println(fmt.Sprintf("Automatically unbooked server \"%s\" from \"%s\", Reason: Idle timeout from too little players", Serv.Name, UserID))
+				}
+			}(&Conf.Servers[i])
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -165,5 +165,6 @@ func MessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 func SetupCron() {
 	c = cron.New()
 	c.AddFunc("*/1 * * * *", CheckUnbookServers)
+	c.AddFunc("0 * * * *", CheckIdleMinutes)
 	c.Start()
 }

--- a/server.go
+++ b/server.go
@@ -25,6 +25,8 @@ type Server struct {
 
 	host string
 	port int
+
+	idleMinutes int
 }
 
 // Returns whether the server is currently available for booking.
@@ -42,6 +44,18 @@ func (s *Server) GetBooker() string {
 
 func (s *Server) GetBookerMention() string {
 	return s.bookerMention
+}
+
+func (s *Server) GetIdleMinutes() int {
+	return s.idleMinutes
+}
+
+func (s *Server) AddIdleMinute() {
+	s.idleMinutes++
+}
+
+func (s *Server) ResetIdleMinutes() {
+	s.idleMinutes = 0
 }
 
 // Setup the server with a randomised RCON password & server password from a bash script.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "2avCvSn0XonfApKKuTMyiQmk7s0=",
+			"path": "github.com/Sirupsen/logrus",
+			"revision": "3ec0642a7fb6488f65b06f9040adc67e3990296a",
+			"revisionTime": "2016-08-29T20:23:21Z"
+		},
+		{
 			"checksumSHA1": "Vzxe0C8yKCQwMZglGqmztF+HD9w=",
 			"path": "github.com/bwmarrin/discordgo",
 			"revision": "f878362d73b01a051091faaa012deeb7a85204af",
@@ -13,6 +19,12 @@
 			"path": "github.com/gorilla/websocket",
 			"revision": "2d1e4548da234d9cb742cc3628556fef86aafbac",
 			"revisionTime": "2016-09-12T15:30:41Z"
+		},
+		{
+			"checksumSHA1": "yGgcQlZNpKhjZAbElPSECbSSNXE=",
+			"path": "github.com/kidoman/go-steam",
+			"revision": "2e40e0d508cbac591bab4ae18b231153295f3a0a",
+			"revisionTime": "2014-12-21T01:56:29Z"
 		},
 		{
 			"checksumSHA1": "PphQA6j/DEDbg3WIsdBDYALOOYs=",
@@ -37,6 +49,12 @@
 			"path": "golang.org/x/crypto/salsa20/salsa",
 			"revision": "5f31782cfb2b6373211f8f9fbf31283fa234b570",
 			"revisionTime": "2016-10-12T21:56:05Z"
+		},
+		{
+			"checksumSHA1": "Xz3hUrPvOYGWTuHrEryoYAj9zwg=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "9bb9f0998d48b31547d975974935ae9b48c7a03c",
+			"revisionTime": "2016-10-11T23:07:22Z"
 		}
 	],
 	"rootPath": "alex-j-butler.com/tf2-booking"


### PR DESCRIPTION
Add idle unbooking if the server is not being used. Add configuration variables 'max_idle_minutes' specifying the maximum amount of minutes a server can be empty before unbooking, and 'min_players' specifying the minimum players on a server for it to be considered idle.
