### PR TITLE
Fix AppVeyor building for multiple packages.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,10 @@ install:
 build_script:
   - set GOOS=linux
   - set GOARCH=amd64
-  - C:\Gopath\bin\govendor build -o tf2-booking-amd64 +local
+  - C:\Gopath\bin\govendor build -o tf2-booking-amd64
   - set GOOS=linux
   - set GOARCH=386
-  - C:\Gopath\bin\govendor build -o tf2-booking-i386 +local
+  - C:\Gopath\bin\govendor build -o tf2-booking-i386
 
 artifacts:
   - path: tf2-booking-amd64


### PR DESCRIPTION
With `+local` appended to the build command, it gave the following error when building: `go build: cannot use -o with multiple packages`, caused by it failing to build the application once a second package has been introduced into the application.
