### PR TITLE
Error notifications if a server reaches the error threshold

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,9 @@ type Config struct {
 	MaxIdleMinutes     int      `json:"max_idle_minutes"`
 	MinPlayers         int      `json:"min_players"`
 
+	ErrorThreshold    int      `json:"error_threshold"`
+	NotificationUsers []string `json:"notification_users"`
+
 	BookingDuration        DurationUtil `json:"booking_duration"`
 	BookingExtendDuration  DurationUtil `json:"booking_extend_duration"`
 	BookingWarningDuration DurationUtil `json:"booking_warning_duration"`

--- a/config.json.example
+++ b/config.json.example
@@ -5,8 +5,16 @@
     [
         "channel id"
     ],
+
     "max_idle_minutes": 2,
     "min_players": 2,
+
+    "error_threshold": 1,
+    "notification_users":
+    [
+        "user id"
+    ],
+
     "servers":
     [
         {

--- a/cron.go
+++ b/cron.go
@@ -61,6 +61,9 @@ func CheckIdleMinutes() {
 				server, err := steam.Connect(Serv.Address)
 				if err != nil {
 					log.Println(fmt.Sprintf("Failed to connect to server \"%s\":", Serv.Name), err)
+
+					HandleQueryError(Serv, err)
+
 					return
 				}
 
@@ -69,6 +72,9 @@ func CheckIdleMinutes() {
 				info, err := server.Info()
 				if err != nil {
 					log.Println(fmt.Sprintf("Failed to query server \"%s\":", Serv.Name), err)
+
+					HandleQueryError(Serv, err)
+
 					return
 				}
 

--- a/error_handling.go
+++ b/error_handling.go
@@ -1,0 +1,44 @@
+package main
+
+import "fmt"
+
+// HandleQueryError handles incrementing the errorMinute value on the server, and
+// notifying an admin via Discord if too many errors occur in a short space of time.
+func HandleQueryError(s *Server, err error) {
+	s.errorMinutes++
+
+	// Too many notifications. Send a message.
+	if s.errorMinutes >= Conf.ErrorThreshold {
+		// Reset the error minutes.
+		s.errorMinutes = 0
+
+		var message string
+		bookerName := "Unknown"
+		if !s.IsAvailable() {
+			u, err := Session.User(s.GetBooker())
+			if err == nil {
+				bookerName = u.Username
+			}
+
+			message = fmt.Sprintf(
+				"The server `%s` failed to be contacted after %d retries after being booked by `%s`. Check to ensure the server is correctly working.",
+				s.Name,
+				s.errorMinutes,
+				bookerName,
+				err,
+			)
+		} else {
+			message = fmt.Sprintf(
+				"The server `%s` failed to be contacted after %d retries while unbooked. Check to ensure the server is correctly working.",
+				s.Name,
+				s.errorMinutes,
+				err,
+			)
+		}
+
+		for _, notificationUser := range Conf.NotificationUsers {
+			UserChannel, _ := Session.UserChannelCreate(notificationUser)
+			Session.ChannelMessageSend(UserChannel.ID, message)
+		}
+	}
+}

--- a/server.go
+++ b/server.go
@@ -30,7 +30,8 @@ type Server struct {
 	host string
 	port int
 
-	idleMinutes int
+	idleMinutes  int
+	errorMinutes int
 }
 
 // Returns whether the server is currently available for booking.


### PR DESCRIPTION
This adds error notifications sent to specific users (privately) when a server fails to respond to a configurable number of pings, letting them know that the server may be having trouble starting/may be crashing.
