### PR TITLE
Choose servers based on previous server performance.

### DIFF
--- a/main.go
+++ b/main.go
@@ -283,5 +283,6 @@ func SetupCron() {
 	c = cron.New()
 	c.AddFunc("*/1 * * * *", CheckUnbookServers)
 	c.AddFunc("0 * * * *", CheckIdleMinutes)
+	c.AddFunc("*/10 * * * *", CheckStats)
 	c.Start()
 }

--- a/servers.go
+++ b/servers.go
@@ -1,15 +1,24 @@
 package main
 
-import ()
+import "math"
 
 func GetAvailableServer() *Server {
-	for i := 0; i < len(Conf.Servers); i++ {
-		if Conf.Servers[i].IsAvailable() {
-			return &Conf.Servers[i]
+	var bestServer *Server
+	var bestDiff float64
+	servers := GetAvailableServers()
+
+	// Higher than the maximum a TF2 tickrate can differ.
+	bestDiff = 4096.0
+	for i := 0; i < len(servers); i++ {
+		server := servers[i]
+
+		if diff := math.Abs(float64(server.TickRate - 66.6666)); diff < bestDiff {
+			bestServer = server
+			bestDiff = diff
 		}
 	}
 
-	return nil
+	return bestServer
 }
 
 func GetAvailableServers() []*Server {

--- a/util/stats.go
+++ b/util/stats.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type Stats struct {
+	CPU        float32
+	InKBs      float32
+	OutKBs     float32
+	Uptime     int
+	MapChanges int
+	FPS        float32
+	Players    int
+	Connects   int
+}
+
+func ParseStats(statsLine string) (*Stats, error) {
+	line := strings.Split(statsLine, "\n")[1]
+	r, _ := regexp.Compile("([0-9\\.]+)")
+	matches := r.FindAllString(line, -1)
+
+	cpu, err := strconv.ParseFloat(matches[0], 32)
+	if err != nil {
+		return nil, err
+	}
+
+	inkbs, err := strconv.ParseFloat(matches[1], 32)
+	if err != nil {
+		return nil, err
+	}
+
+	outkbs, err := strconv.ParseFloat(matches[2], 32)
+	if err != nil {
+		return nil, err
+	}
+
+	uptime, err := strconv.ParseInt(matches[3], 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	mapchanges, err := strconv.ParseInt(matches[4], 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	fps, err := strconv.ParseFloat(matches[5], 32)
+	if err != nil {
+		return nil, err
+	}
+
+	players, err := strconv.ParseInt(matches[6], 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	connects, err := strconv.ParseInt(matches[7], 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Stats{
+		CPU:        float32(cpu),
+		InKBs:      float32(inkbs),
+		OutKBs:     float32(outkbs),
+		Uptime:     int(uptime),
+		MapChanges: int(mapchanges),
+		FPS:        float32(fps),
+		Players:    int(players),
+		Connects:   int(connects),
+	}, nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,6 +21,12 @@
 			"revisionTime": "2016-09-12T15:30:41Z"
 		},
 		{
+			"checksumSHA1": "+cYSZ/ZSKHuhIFeqmD35t6W76ME=",
+			"path": "github.com/james4k/rcon",
+			"revision": "8fbb8268b60ac3303900326e126be05d504ab63d",
+			"revisionTime": "2012-09-23T21:54:19Z"
+		},
+		{
 			"checksumSHA1": "yGgcQlZNpKhjZAbElPSECbSSNXE=",
 			"path": "github.com/kidoman/go-steam",
 			"revision": "2e40e0d508cbac591bab4ae18b231153295f3a0a",


### PR DESCRIPTION
Fixes #6, adds statistics tracking and uses it to choose the most optimal server rather than choosing the next available server in the configuration order.

Note: This is still a work in progress.
