### PR TITLE
Seamless updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 ### Custom ###
 config.json
+.state.json
 tf2-booking
 .vscode
 debug

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -2,16 +2,44 @@ package commands
 
 import (
 	"fmt"
+	"log"
+	"reflect"
 	"strings"
+
+	"alex-j-butler.com/tf2-booking/util"
 
 	"github.com/bwmarrin/discordgo"
 )
 
-type CommandHandler func(*discordgo.MessageCreate, string, []string)
+type CommandFunction func(*discordgo.MessageCreate, string, []string)
+
+type CommandHandler struct {
+	function    CommandFunction
+	permissions int
+	respondToDM bool
+}
 
 type Command struct {
 	Prefix   string
-	Handlers map[string]CommandHandler
+	Handlers map[string]*CommandHandler
+}
+
+func NewCommand(function CommandFunction) *CommandHandler {
+	return &CommandHandler{
+		function:    function,
+		permissions: -1,
+		respondToDM: false,
+	}
+}
+
+func (ch *CommandHandler) Permissions(permissions int) *CommandHandler {
+	ch.permissions = permissions
+	return ch
+}
+
+func (ch *CommandHandler) RespondToDM(respondToDM bool) *CommandHandler {
+	ch.respondToDM = respondToDM
+	return ch
 }
 
 // New creates a new instance of the Command system
@@ -19,16 +47,16 @@ type Command struct {
 func New(prefix string) *Command {
 	return &Command{
 		Prefix:   prefix,
-		Handlers: make(map[string]CommandHandler),
+		Handlers: make(map[string]*CommandHandler),
 	}
 }
 
 // Add creates a new entry in the command handlers map.
 // First argument accepts a command handler implementing the type `CommandHandler`,
 // Second argument accepts a variable amount of strings specifying the commands to register.
-func (c *Command) Add(handler CommandHandler, commands ...string) {
+func (c *Command) Add(handler *CommandHandler, commands ...string) {
 	for _, command := range commands {
-		c.Handlers[fmt.Sprintf("%s%s", c.Prefix, command)] = handler
+		c.Handlers[command] = handler
 	}
 }
 
@@ -41,17 +69,41 @@ func (c *Command) Remove(commands ...string) {
 
 // Handle the incoming commands and dispatches them to the appropriate
 // command handler, after parsing them.
-func (c *Command) Handle(m *discordgo.MessageCreate, command string) {
+func (c *Command) Handle(session *discordgo.Session, m *discordgo.MessageCreate, command string, permissions int) {
 	for str, handler := range c.Handlers {
-		if command == str {
-			var fixedCommand string
-			if strings.HasPrefix(command, c.Prefix) {
-				fixedCommand = command[len(c.Prefix):len(command)]
-			} else {
-				fixedCommand = command
+		if !strings.HasPrefix(command, c.Prefix) && c.Prefix != "" {
+			continue
+		}
+
+		handlerSplit := strings.Split(str, " ")
+		commandSplit := strings.Split(command[len(c.Prefix):], " ")
+
+		if len(commandSplit) < len(handlerSplit) {
+			continue
+		}
+
+		if !handler.respondToDM {
+			channel, err := session.State.Channel(m.ChannelID)
+			if err != nil {
+				log.Println("Failed to lookup channel.", err)
 			}
 
-			handler(m, fixedCommand, nil)
+			if channel.IsPrivate {
+				continue
+			}
+		}
+
+		if reflect.DeepEqual(handlerSplit, commandSplit[:len(handlerSplit)]) {
+			log.Println(fmt.Sprintf("Permissions test: %d & %d = %d", permissions, handler.permissions, permissions&handler.permissions))
+
+			if permissions&handler.permissions != 0 {
+				handler.function(m, strings.Join(handlerSplit, " "), commandSplit[len(handlerSplit):])
+			} else {
+				User := &util.PatchUser{m.Author}
+				session.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s: You don't have permission for that command.", User.GetMention()))
+			}
+
+			break
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -34,7 +34,19 @@ func main() {
 	SetupCron()
 
 	if HasState(".state.json") {
-		LoadState(".state.json")
+		err, servers, users, userServers := LoadState(".state.json")
+
+		if err != nil {
+			log.Println("Found state file, failed to restore:", err)
+		} else {
+			log.Println("Found state file, restoring from previous state.")
+
+			Conf.Servers = servers
+			Users = users
+			UserServers = userServers
+		}
+	} else {
+		log.Println("No state file found.")
 	}
 
 	// Register the commands and their command handlers.

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	Users = make(map[string]bool)
 	UserServers = make(map[string]*Server)
 
-	// Restore state.
+	// Restore state from the state file, if it exists.
 	if HasState(".state.json") {
 		err, servers, users, userServers := LoadState(".state.json")
 

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	Command.Add(UnbookServer, "return", "return a server", "unbook", "unbook a server")
 	Command.Add(ExtendServer, "extend", "extend a server", "extend my server", "extend booking", "extend my booking")
 	Command.Add(Save, "save", "save state")
+	Command.Add(Print, "print", "print state")
 
 	// Create maps.
 	Users = make(map[string]bool)
@@ -281,6 +282,14 @@ func Save(m *discordgo.MessageCreate, command string, args []string) {
 
 	SaveState(".state.json", Conf.Servers, Users, UserServers)
 	Session.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s: Saved state.", User.GetMention()))
+}
+
+func Print(m *discordgo.MessageCreate, command string, args []string) {
+	User := &PatchUser{m.Author}
+
+	Session.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s: Servers state: %v", User.GetMention(), Conf.Servers))
+	Session.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s: Users state: %v", User.GetMention(), Users))
+	Session.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s: UserServers state: %v", User.GetMention(), UserServers))
 }
 
 // MessageCreate handler for Discord.

--- a/main.go
+++ b/main.go
@@ -33,11 +33,16 @@ func main() {
 	InitialiseConfiguration()
 	SetupCron()
 
+	if HasState(".state.json") {
+		LoadState(".state.json")
+	}
+
 	// Register the commands and their command handlers.
 	Command = commands.New("")
 	Command.Add(BookServer, "book a server", "book")
 	Command.Add(UnbookServer, "return", "return a server", "unbook", "unbook a server")
 	Command.Add(ExtendServer, "extend", "extend a server", "extend my server", "extend booking", "extend my booking")
+	Command.Add(Save, "save", "save state")
 
 	// Create maps.
 	Users = make(map[string]bool)
@@ -257,6 +262,13 @@ func ExtendServer(m *discordgo.MessageCreate, command string, args []string) {
 
 		return
 	}
+}
+
+func Save(m *discordgo.MessageCreate, command string, args []string) {
+	User := &PatchUser{m.Author}
+
+	SaveState(".state.json")
+	Session.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s: Saved state.", User.GetMention()))
 }
 
 // MessageCreate handler for Discord.

--- a/main.go
+++ b/main.go
@@ -279,7 +279,7 @@ func ExtendServer(m *discordgo.MessageCreate, command string, args []string) {
 func Save(m *discordgo.MessageCreate, command string, args []string) {
 	User := &PatchUser{m.Author}
 
-	SaveState(".state.json")
+	SaveState(".state.json", Conf.Servers, Users, UserServers)
 	Session.ChannelMessageSend(m.ChannelID, fmt.Sprintf("%s: Saved state.", User.GetMention()))
 }
 

--- a/update.go
+++ b/update.go
@@ -45,9 +45,9 @@ func HasState(save string) bool {
 	return err == nil
 }
 
-func SaveState(save string, users map[string]bool, userServers StringServerMap) error {
+func SaveState(save string, servers []Server, users map[string]bool, userServers StringServerMap) error {
 	state := State{
-		Servers:     Conf.Servers,
+		Servers:     servers,
 		Users:       users,
 		UserStrings: userServers.ToStringMap(),
 	}

--- a/update.go
+++ b/update.go
@@ -6,13 +6,53 @@ import (
 	"os"
 )
 
+type StringServerMap map[string]*Server
+type StringStringMap map[string]string
+
+func (m StringServerMap) ToStringMap() StringStringMap {
+	newMap := make(StringStringMap)
+	for k, v := range m {
+		newMap[k] = v.SessionName
+	}
+
+	return newMap
+}
+
+func (m StringStringMap) ToServerMap(servers []*Server) StringServerMap {
+	newMap := make(StringServerMap)
+	for k, v := range m {
+		var serv *Server
+		for _, s := range servers {
+			if s.SessionName == v {
+				serv = s
+			}
+		}
+
+		newMap[k] = serv
+	}
+
+	return newMap
+}
+
+type State struct {
+	Servers     []Server
+	Users       map[string]bool
+	UserStrings StringStringMap
+}
+
 func HasState(save string) bool {
 	_, err := os.Stat(save)
 	return err == nil
 }
 
-func SaveState(save string) error {
-	j, err := json.Marshal(Conf.Servers)
+func SaveState(save string, users map[string]bool, userServers StringServerMap) error {
+	state := State{
+		Servers:     Conf.Servers,
+		Users:       users,
+		UserStrings: userServers.ToStringMap(),
+	}
+
+	j, err := json.Marshal(state)
 
 	if err != nil {
 		return err
@@ -23,15 +63,21 @@ func SaveState(save string) error {
 	return err
 }
 
-func LoadState(save string) error {
+func LoadState(save string) (error, []Server, map[string]bool, map[string]*Server) {
 	j, err := ioutil.ReadFile(save)
 
 	if err != nil {
-		return err
+		return err, nil, nil, nil
 	}
 
-	Conf.Servers = []Server{}
-	err = json.Unmarshal(j, &Conf.Servers)
+	state := State{}
+	err = json.Unmarshal(j, &state)
 
-	return err
+	servers := make([]*Server, len(Conf.Servers))
+	for i, j := range state.Servers {
+		servers[i] = &j
+	}
+	userServers := state.UserStrings.ToServerMap(servers)
+
+	return err, state.Servers, state.Users, userServers
 }

--- a/update.go
+++ b/update.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+func HasState(save string) bool {
+	_, err := os.Stat(save)
+	return err == nil
+}
+
+func SaveState(save string) error {
+	j, err := json.Marshal(Conf.Servers)
+
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(save, j, 0644)
+
+	return err
+}
+
+func LoadState(save string) error {
+	j, err := ioutil.ReadFile(save)
+
+	if err != nil {
+		return err
+	}
+
+	Conf.Servers = []Server{}
+	err = json.Unmarshal(j, &Conf.Servers)
+
+	return err
+}

--- a/util/patch.go
+++ b/util/patch.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import (
 	"fmt"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -21,6 +21,24 @@
 			"revisionTime": "2016-09-12T15:30:41Z"
 		},
 		{
+			"checksumSHA1": "YjZiQ5N552dJ7GpJ2P4TTRu4PKI=",
+			"path": "github.com/inconshreveable/go-update",
+			"revision": "8152e7eb6ccf8679a64582a66b78519688d156ad",
+			"revisionTime": "2016-01-12T19:33:35Z"
+		},
+		{
+			"checksumSHA1": "LeFW+ad/zlj30+Z0O4wwnXrVUSQ=",
+			"path": "github.com/inconshreveable/go-update/internal/binarydist",
+			"revision": "8152e7eb6ccf8679a64582a66b78519688d156ad",
+			"revisionTime": "2016-01-12T19:33:35Z"
+		},
+		{
+			"checksumSHA1": "H63+DW/S2nASpHk59G1wEUZD1qk=",
+			"path": "github.com/inconshreveable/go-update/internal/osext",
+			"revision": "8152e7eb6ccf8679a64582a66b78519688d156ad",
+			"revisionTime": "2016-01-12T19:33:35Z"
+		},
+		{
 			"checksumSHA1": "+cYSZ/ZSKHuhIFeqmD35t6W76ME=",
 			"path": "github.com/james4k/rcon",
 			"revision": "8fbb8268b60ac3303900326e126be05d504ab63d",


### PR DESCRIPTION
Added a new seamless updating feature with state saving and restoration.

The updating feature can be used through the `update` command, which is accessible by users with the 'Manage Server' Discord permission in the current channel, or in the default channel if the command is sent through Private message.

This also updates the command system, changing the way commands are registered allowing permissions to be chosen and whether the command will be accepted in Private messages to the bot.